### PR TITLE
feat!: rename extention

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,4 +31,4 @@ jobs:
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')
         with:
-          files: vscode-quick-toggle-multilingual-content-${{steps.version.outputs.prop}}.vsix
+          files: vscode-toggle-multilingual-content-${{steps.version.outputs.prop}}.vsix

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# vscode-quick-toggle-multilingual-content
+# vscode-toggle-multilingual-content
 
 A VSCode extension that switch multilingual content files with shortcut key and command pallet.
 
@@ -9,7 +9,7 @@ Available commands:
 ```json
 "commands": [
   {
-    "command": "com.github.chick-p.vscode-quick-toggle-multilingual-content.toggle",
+    "command": "com.github.chick-p.vscode-toggle-multilingual-content.toggle",
     "title": "Toggle Multilingual Content File"
   }
 ],
@@ -17,7 +17,7 @@ Available commands:
   {
     "mac": "cmd+9",
     "key": "ctrl+9",
-    "command": "com.github.chick-p.vscode-quick-toggle-multilingual-content.toggle"
+    "command": "com.github.chick-p.vscode-toggle-multilingual-content.toggle"
   }
 ]
 ```
@@ -28,7 +28,7 @@ Available settings:
 
 ```plaintext
 // A list of languages
-"vscode-quick-toggle-multilingual-content.languages": [
+"vscode-toggle-multilingual-content.languages": [
   "ja",
   "en",
   "zh",
@@ -36,10 +36,10 @@ Available settings:
 ],
 
 // The directory of content files.
-"vscode-quick-toggle-multilingual-content.contentDir": "content",
+"vscode-toggle-multilingual-content.contentDir": "content",
 
 // Manage content files by filename as `about.fr.md
-"vscode-quick-toggle-multilingual-content.isManagedByFilename": false
+"vscode-toggle-multilingual-content.isManagedByFilename": false
 ```
 
 ## Installation
@@ -49,5 +49,5 @@ Install locally:
 
 ```shell
 npx vsce package
-code --install-extension vscode-quick-toggle-multilingual-content-0.0.1.vsix
+code --install-extension vscode-toggle-multilingual-content-0.0.1.vsix
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "vscode-quick-toggle-multilingual-content",
-  "displayName": "vscode-quick-toggle-multilingual-content",
+  "name": "vscode-toggle-multilingual-content",
+  "displayName": "vscode-toggle-multilingual-content",
   "description": "Switch multilingual contents with shortcut key",
   "version": "0.0.2",
   "engines": {
@@ -10,13 +10,13 @@
     "Other"
   ],
   "activationEvents": [
-    "onCommand:com.github.chick-p.vscode-quick-toggle-multilingual-content.toggle"
+    "onCommand:com.github.chick-p.vscode-toggle-multilingual-content.toggle"
   ],
   "main": "./out/extension.js",
   "contributes": {
     "commands": [
       {
-        "command": "com.github.chick-p.vscode-quick-toggle-multilingual-content.toggle",
+        "command": "com.github.chick-p.vscode-toggle-multilingual-content.toggle",
         "title": "Toggle Multilingual Content File"
       }
     ],
@@ -24,13 +24,13 @@
       {
         "mac": "cmd+9",
         "key": "ctrl+9",
-        "command": "com.github.chick-p.vscode-quick-toggle-multilingual-content.toggle"
+        "command": "com.github.chick-p.vscode-toggle-multilingual-content.toggle"
       }
     ],
     "configuration": {
-      "title": "Toggle Quick Multilingual Content",
+      "title": "Toggle Multilingual Content",
       "properties": {
-        "vscode-quick-toggle-multilingual-content.languages": {
+        "vscode-toggle-multilingual-content.languages": {
           "type": "array",
           "items": {
             "type": "string"
@@ -43,12 +43,12 @@
           ],
           "description": "A list of languages"
         },
-        "vscode-quick-toggle-multilingual-content.contentDir": {
+        "vscode-toggle-multilingual-content.contentDir": {
           "type": "string",
           "default": "content",
           "description": "The directory of content files."
         },
-        "vscode-quick-toggle-multilingual-content.isManagedByFilename": {
+        "vscode-toggle-multilingual-content.isManagedByFilename": {
           "type": "boolean",
           "default": false,
           "description": "Manage content files by filename as `about.fr.md`"
@@ -88,6 +88,6 @@
     "typescript": "^4.5.5",
     "vsce": "^2.7.0"
   },
-  "repository": "https://github.com/chick-p/vscode-quick-toggle-multilingual-content",
+  "repository": "https://github.com/chick-p/vscode-toggle-multilingual-content",
   "license": "MIT"
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -13,7 +13,7 @@ interface GetConfig {
 
 export const getConfig: GetConfig = <K extends keyof Config>(key?: K) => {
   const config = vscode.workspace.getConfiguration(
-    "vscode-quick-toggle-multilingual-content"
+    "vscode-toggle-multilingual-content"
   );
   return key ? config[key] : config;
 };

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,7 +6,7 @@ import { getConfig } from "./config";
 import { QuickPickItem } from "vscode";
 
 export function activate(context: vscode.ExtensionContext) {
-  console.log('"vscode-quick-toggle-multilingual-content" is now active!');
+  console.log('"vscode-toggle-multilingual-content" is now active!');
 
   const buildLanguageFileNames = (
     fileName: string
@@ -74,7 +74,7 @@ export function activate(context: vscode.ExtensionContext) {
     );
 
   const disposable = vscode.commands.registerCommand(
-    "com.github.chick-p.vscode-quick-toggle-multilingual-content.toggle",
+    "com.github.chick-p.vscode-toggle-multilingual-content.toggle",
     async () => {
       const editor = vscode.window.activeTextEditor;
       if (!editor) {


### PR DESCRIPTION
`vscode-quick-toggle-multilingual-content` -> `vscode-toggle-multilingual-content`